### PR TITLE
Green flash

### DIFF
--- a/src/Emanate.Core/Input/TeamCity/ITeamCityConnection.cs
+++ b/src/Emanate.Core/Input/TeamCity/ITeamCityConnection.cs
@@ -5,5 +5,6 @@ namespace Emanate.Core.Input.TeamCity
         string GetProjects();
         string GetProject(string projectId);
         string GetBuild(string buildId);
+        string GetBuilds(string buildId, int count);
     }
 }

--- a/src/Emanate.Core/Input/TeamCity/TeamCityConnection.cs
+++ b/src/Emanate.Core/Input/TeamCity/TeamCityConnection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Net;
 
@@ -38,7 +38,12 @@ namespace Emanate.Core.Input.TeamCity
 
         public string GetBuild(string buildId)
         {
-            var resultUri = CreateUri(string.Format("httpAuth/app/rest/builds?locator=running:all,buildType:(id:{0}),count:1", buildId));
+            return GetBuilds(buildId, 1);
+        }
+
+        public string GetBuilds(string buildId, int count)
+        {
+            var resultUri = CreateUri(string.Format("httpAuth/app/rest/builds?locator=running:all,buildType:(id:{0}),count:" + count, buildId));
             return Request(resultUri);
         }
 

--- a/src/Emanate.Core/Output/DelcomVdi/DelcomOutput.cs
+++ b/src/Emanate.Core/Output/DelcomVdi/DelcomOutput.cs
@@ -76,8 +76,17 @@ namespace Emanate.Core.Output.DelcomVdi
                     break;
                 case BuildState.Running:
                     device.TurnOff(Color.Red);
-                    device.TurnOff(Color.Green);
-                    device.Flash(Color.Yellow);
+
+                    if (lastCompletedState == BuildState.Succeeded)
+                    {
+                        device.TurnOff(Color.Yellow);
+                        device.Flash(Color.Green);
+                    }
+                    else
+                    {
+                        device.TurnOff(Color.Green);
+                        device.Flash(Color.Yellow);
+                    }
                     break;
                 default:
                     device.Flash(Color.Red);

--- a/src/Emanate.UnitTests/Core/Input/TeamCity/MockTeamCityConnection.cs
+++ b/src/Emanate.UnitTests/Core/Input/TeamCity/MockTeamCityConnection.cs
@@ -144,6 +144,22 @@ namespace Emanate.UnitTests.Core.Input.TeamCity
             return sb.ToString();
         }
 
+        public string GetBuilds(string buildId, int count)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine(@"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes"" ?>");
+            sb.AppendLine(@"<builds>");
+
+            var builds = projects.SelectMany(p => p.Value.Where(b => b.Id == buildId));
+            foreach (var build in builds)
+            {
+                var runningXml = build.IsRunning ? @"running=""true"" percentageComplete=""35""" : "";
+                sb.AppendFormat(@"<build id=""999"" {0} status=""{1}"" buildTypeId=""{2}"" startDate=""20000101T120000+1300"" /> {3}", runningXml, build.Status, build.Id, Environment.NewLine);
+            }
+            sb.AppendLine(@"</builds>");
+            return sb.ToString();
+        }
+
         public void SetBuildStatus(string buildName, string status, bool isRunning = false)
         {
             var builds = projects.SelectMany(p => p.Value.Where(b => b.Name == buildName));


### PR DESCRIPTION
Makes the lights flash green if a build is running and the last build was successful. It's necessary for the trunk CI as it tends to be running continuously at the end of the day when everyone's checking in.